### PR TITLE
Remove unnecessary logic from tf-validate.yml

### DIFF
--- a/.github/workflows/tf-validate.yml
+++ b/.github/workflows/tf-validate.yml
@@ -28,17 +28,9 @@ jobs:
       - name: Check changed files
         id: diff
         run: |
-          if [ $GITHUB_BASE_REF ]; then
-            # Pull Request
-            git fetch origin $GITHUB_BASE_REF --depth=1
-            export DIFF=$( git diff --dirstat=files,0,cumulative origin/$GITHUB_BASE_REF $GITHUB_SHA | awk -F ' ' '{print $2}' | grep -vE '(^.github|^scripts|^tests)' )
-            echo "PR Diff between origin/$GITHUB_BASE_REF and $GITHUB_SHA"
-          else
-            # Push
-            git fetch origin ${{ github.event.before }} --depth=1
-            export DIFF=$( git diff --dirstat=files,0,cumulative ${{ github.event.before }} $GITHUB_SHA | awk -F ' ' '{print $2}' | grep -vE '(^.github|^scripts|^tests)' )
-            echo "Push Diff between ${{ github.event.before }} and $GITHUB_SHA"
-          fi
+          git fetch origin ${{ github.event.before }} --depth=1
+          export DIFF=$( git diff --dirstat=files,0,cumulative ${{ github.event.before }} $GITHUB_SHA | awk -F ' ' '{print $2}' | grep -vE '(^.github|^scripts|^tests)' )
+          echo "Push Diff between ${{ github.event.before }} and $GITHUB_SHA"
           echo "$DIFF"
           # Escape newlines (replace \n with %0A)
           echo "::set-output name=diff::$( echo "$DIFF" | sed ':a;N;$!ba;s/\n/%0A/g' )"

--- a/apps/app2/README.md
+++ b/apps/app2/README.md
@@ -21,3 +21,6 @@ No additional info.
 | Name | Description |
 |------|-------------|
 | app2\_region | the region input variable |
+
+# TEST
+modifying a file to trigger tf-validate.

--- a/apps/app2/README.md
+++ b/apps/app2/README.md
@@ -21,6 +21,3 @@ No additional info.
 | Name | Description |
 |------|-------------|
 | app2\_region | the region input variable |
-
-# TEST
-modifying a file to trigger tf-validate.


### PR DESCRIPTION
Update the tf-validate to remove the if/then/else that separated Pull Requests from Pushes. This wasn't necessary since the workflow begins with GHA logic to only run on pushes. Once this is merged to main, I will need to run a more thorough test of creating a new branch in a monitored path and do an initial push.