### PR TITLE
Terraform update

### DIFF
--- a/.github/workflows/tf-apply-dev.yml
+++ b/.github/workflows/tf-apply-dev.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Terraform Setup
         uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 0.12.29
+          terraform_version: 0.12.31
 
       # Create the terraform.tfvars file
       - name: Create tfvars

--- a/.github/workflows/tf-apply-global.yml
+++ b/.github/workflows/tf-apply-global.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Terraform Setup
         uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 0.12.29
+          terraform_version: 0.12.31
 
       # Create the terraform.tfvars file
       - name: Create tfvars

--- a/.github/workflows/tf-network-apply.yml
+++ b/.github/workflows/tf-network-apply.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Terraform Setup
         uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 0.12.29
+          terraform_version: 0.12.31
 
       # Create the terraform.tfvars file
       - name: Create tfvars

--- a/.github/workflows/tf-network-destroy.yml
+++ b/.github/workflows/tf-network-destroy.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Terraform Setup
         uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 0.12.29
+          terraform_version: 0.12.31
 
       # Create the terraform.tfvars file
       - name: Create tfvars

--- a/.github/workflows/tf-plan-dev.yml
+++ b/.github/workflows/tf-plan-dev.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Terraform Setup
         uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 0.12.29
+          terraform_version: 0.12.31
 
       # Setup Python
       - name: Setup Python

--- a/.github/workflows/tf-plan-global.yml
+++ b/.github/workflows/tf-plan-global.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Terraform Setup
         uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 0.12.29
+          terraform_version: 0.12.31
 
       # Create the terraform.tfvars file
       - name: Create tfvars

--- a/.github/workflows/tf-promote.yml
+++ b/.github/workflows/tf-promote.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Terraform Setup
         uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 0.12.29
+          terraform_version: 0.12.31
 
       # Create the terraform.tfvars file
       - name: Create tfvars

--- a/.github/workflows/tf-validate.yml
+++ b/.github/workflows/tf-validate.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Terraform Setup
         uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 0.12.29
+          terraform_version: 0.12.31
     
       # Run Terraform Validate
       - name: Validate

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GitHub Workflow Testing Template
 
-This is a Terraform monorepo used for testing GitHub Actions workflows. For more detailed documentation, see this private KB article [InfraEng KB](https://mitlibraries.atlassian.net/l/c/pu7F0K40).
+This is a Terraform monorepo used for testing GitHub Actions workflows. For more detailed documentation, see this private KB article [InfraEng KB](https://mitlibraries.atlassian.net/l/c/pu7F0K40). As of May 5th, 2021, the workflows use Terraform version 0.12.31.
 
 ## Workflows
 

--- a/apps/app1/versions.tf
+++ b/apps/app1/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = "= 0.12.29"
+  required_version = "= 0.12.31"
 }

--- a/apps/app2/versions.tf
+++ b/apps/app2/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = "= 0.12.29"
+  required_version = "= 0.12.31"
 }

--- a/modules/tf-mod-shared-core/versions.tf
+++ b/modules/tf-mod-shared-core/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = "= 0.12.29"
+  required_version = ">= 0.12.31"
 }

--- a/modules/tf-mod-shared-network/versions.tf
+++ b/modules/tf-mod-shared-network/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = "= 0.12.29"
+  required_version = ">= 0.12.31"
 }

--- a/shared/core/versions.tf
+++ b/shared/core/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = "= 0.12.29"
+  required_version = ">= 0.12.31"
 }

--- a/shared/network/versions.tf
+++ b/shared/network/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = "= 0.12.29"
+  required_version = ">= 0.12.31"
 }


### PR DESCRIPTION
Updates GitHub Actions and the rest of the code to reference Terraform 0.12.31 instead of 0.12.29.