### PR TITLE
GitHub Action - fix tf-validate on initial push

### DIFF
--- a/.github/workflows/tf-validate.yml
+++ b/.github/workflows/tf-validate.yml
@@ -1,24 +1,29 @@
 name: Terraform Validate
 
+# The following determines when this workflow will run. For starters, this workflow will
+#   be automatically triggered on any push to a branch other then main or master. It only
+#   looks for changes to Terraform files (`*.tf) in the various folders and subfolders.
 on: 
   push: 
     branches-ignore:
       - 'main'
-    paths-ignore:
-      - '.github/**'
-      - 'scripts/**'
-      - 'tests/**'
-  workflow_dispatch:
+    paths:
+      - 'apps/**/*.tf'
+      - 'modules/**/*.tf'
+      - 'shared/**/*.tf'
 
-# Set defaults
+# Set default shell to /bin/bash
 defaults:
   run:
     shell: bash
 
 jobs:
   generate-matrix:
-    # See https://github.community/t/check-pushed-file-changes-with-git-diff-tree-in-github-actions/17220/10 for the 
-    #   source of this block of code. The first job builds the matrix of folders with terraform changes.
+    # See https://github.community/t/check-pushed-file-changes-with-git-diff-tree-in-github-actions/17220/10 
+    #   for the original source of this block of code. The first job builds the matrix of folders with 
+    #   Terraform changes. The output from this job is a "matrix", basically a list of subfolders where the 
+    #   Terraform commands should run. This will ONLY run the terraform validate on the subfolders where there 
+    #   are actual changes and it will ignore the rest of the repository.
     name: Generate matrix for build
     runs-on: ubuntu-latest
     outputs:
@@ -27,15 +32,26 @@ jobs:
       - uses: actions/checkout@v2
       - name: Check changed files
         id: diff
-        if: github.event.before != '0000000000000000000000000000000000000000'
         run: |
-          git fetch origin ${{ github.event.before }} --depth=1
-          export DIFF=$( git diff --dirstat=files,0,cumulative ${{ github.event.before }} $GITHUB_SHA | awk -F ' ' '{print $2}' | grep -vE '(^.github|^scripts|^tests)' )
-          echo "Push Diff between ${{ github.event.before }} and $GITHUB_SHA"
-          echo "$DIFF"
+          if [github.event.before != '0000000000000000000000000000000000000000']; then
+            git fetch origin main --depth=1
+            export MAIN_SHA=$( git rev-parse origin/main )
+            export DIFF=$( git diff --dirstat=files,0,cumulative $MAIN_SHA $GITHUB_SHA | awk -F ' ' '{print $2}' | grep -vE '(^.github|^scripts|^tests|ansible|packer|vagrant)' )
+            echo "Push Diff between $MAIN_SHA and $GITHUB_SHA"
+            echo "$DIFF"
+          else
+            git fetch origin ${{ github.event.before }} --depth=1
+            export DIFF=$( git diff --dirstat=files,0,cumulative ${{ github.event.before }} $GITHUB_SHA | awk -F ' ' '{print $2}' | grep -vE '(^.github|^scripts|^tests|ansible|packer|vagrant)' )
+            echo "Push Diff between ${{ github.event.before }} and $GITHUB_SHA"
+            echo "$DIFF"
+          fi
           # Escape newlines (replace \n with %0A)
           echo "::set-output name=diff::$( echo "$DIFF" | sed ':a;N;$!ba;s/\n/%0A/g' )"
-      - name: Set matrix for build
+      - name: Set matrix for terraform validate
+      # This block actually creates the matrix. See https://stackoverflow.com/a/62953566/11948346 for the original source of
+      #   this code. It sets two variables, DIFF and JSON, and then loops through the lines, only adding entries if it doesn't
+      #   already exist. Finally, it removes the trailing comma and adds the closing brackets with the result being a properly
+      #   formatted matrix for the next job.
         id: set-matrix
         run: |
           # See https://stackoverflow.com/a/62953566/11948346
@@ -60,15 +76,22 @@ jobs:
           # Set output
           echo "::set-output name=matrix::$( echo "$JSON" )"
 
-  validate:
-    # Set workflow environment variables
+  validatetwelve:
+  # This job executes the `terraform validate` job (for Terraform v0.12.31) for each of the subfolders in the matrix 
+  #   output from the previous job. We start by setting environment variables that will be used throughout this 
+  #   job: the AWS region and the AWS access key and secret (the latter two are stored as secrets in the GitHub 
+  #   repository). For some reason, even with `terraform init -backend=false` the `terraform validate` wants AWS 
+  #   credentials and some of our code requires that it is run in a workspace, so we set `TF_WORKSPACE` to `stage`.
     env:
       AWS_DEFAULT_REGION: us-east-1
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     
-    # This splits out a matrix of jobs that process each of the folders with updates to terraform code.
     name: Check Terraform syntax on "${{ matrix.tfpaths }}"
+    # For each subfolder (path) in the matrix, this will run through the process of validating the terraform
+    #   code. It starts by creating the job(s) from the matrix (typically just one job). Then it checks out the
+    #   repository from GitHub and loads the terraform GitHub Action module, specifying an explicit version of
+    #   Terraform. Finally, it runs `terraform fmt`, `terraform init` (with no backend), and `terraform validate`. 
     needs: generate-matrix
     strategy:
       matrix: ${{fromJson(needs.generate-matrix.outputs.matrix)}}
@@ -81,10 +104,48 @@ jobs:
       - name: Terraform Setup
         uses: hashicorp/setup-terraform@v1
         with:
+          terraform_version: 0.12.31
+    
+      # Run Terraform checks: first check canonical formatting (fmt -check -recusive), then init and validate.
+      #   All of these are run in the `stage` workspace (TF_WORKSPACE is set as an environment variable above).
+      - name: Format check and Validate
+        run: |
+          echo "${{ matrix.tfpaths }}"
+          terraform fmt -check -recursive; terraform init -backend=false; terraform validate
+        working-directory: ${{ matrix.tfpaths }}
+
+  validatethirteen:
+  # This job executes the `terraform validate` job (for Terraform v0.13.7) for each of the subfolders in the matrix 
+  #   output from the previous job. We start by setting environment variables that will be used throughout this 
+  #   job: the AWS region and the AWS access key and secret (the latter two are stored as secrets in the GitHub 
+  #   repository). For some reason, even with `terraform init -backend=false` the `terraform validate` wants AWS 
+  #   credentials and some of our code requires that it is run in a workspace, so we set `TF_WORKSPACE` to `stage`.
+    env:
+      AWS_DEFAULT_REGION: us-east-1
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    
+    name: Check Terraform syntax on "${{ matrix.tfpaths }}"
+    # For each subfolder (path) in the matrix, this will run through the process of validating the terraform
+    #   code. It starts by creating the job(s) from the matrix (typically just one job). Then it checks out the
+    #   repository from GitHub and loads the terraform GitHub Action module, specifying an explicit version of
+    #   Terraform. Finally, it runs `terraform fmt`, `terraform init` (with no backend), and `terraform validate`. 
+    needs: generate-matrix
+    strategy:
+      matrix: ${{fromJson(needs.generate-matrix.outputs.matrix)}}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Terraform Setup
+        uses: hashicorp/setup-terraform@v1
+        with:
           terraform_version: 0.13.7
     
-      # Run Terraform Validate
-      - name: Validate
+      # Run Terraform checks: first check canonical formatting (fmt -check -recusive), then init and validate.
+      #   All of these are run in the `stage` workspace (TF_WORKSPACE is set as an environment variable above).
+      - name: Format check and Validate
         run: |
           echo "${{ matrix.tfpaths }}"
           terraform fmt -check -recursive; terraform init -backend=false; terraform validate

--- a/shared/core/core.tf
+++ b/shared/core/core.tf
@@ -7,3 +7,4 @@ module "label" {
 }
 
 # This creates a simple EC2 instance.
+# This should trigger tf-validate


### PR DESCRIPTION
#### Developer Checklist

- [N/A] The README contains the correct list of dependencies, inputs, and outputs (e.g., `terraform-docs markdown .` has been run)
- [N/A] Latest versions of `dev.tfvars` and `test.tfvars` uploaded to Parameter Store using `./scripts/parameter_update.py` script
- [N/A] Infrastructure resources in this feature are currently NOT deployed in `dev` workspace (opening this PR will trigger a `terraform plan` in the `dev` workspace for review)
- [N/A] Stakeholder approval has been confirmed (or is not needed)

#### What does this PR do?

The tf-validate workflow (since it was first introduced to replace the
TravisCI automation) has always failed on the very first push of a new
branch to GitHub. This update addresses that problem.

How this addresses that need:
* Remove the `steps.if: ...` logic in the "generate matrix" job
* Add `if .. then .. else .. fi` logic to the bash commands in the
"generate matrix" job's `run:` command.
* On first push (when $github.event.before=all-zeros), compare the new
branch to `origin/main` with the `git diff` command
* Update the `validate` jobs to reflect the changes that were
implemented in the terraform-testdev-* and mitlib-terraform
repositories.

Additionally, the in-line documentation was updated to reflect the same
documentation that is in the Dev/Test repos and the Stage/Prod repo.

Side effects of this change:
There are no side effects of this change. It does assume that all new
branches created by developers are branch from `origin/main`.

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
